### PR TITLE
Latest version update issue

### DIFF
--- a/install.js
+++ b/install.js
@@ -231,7 +231,7 @@ function getLatestVersion(requestOptions) {
     if (err) {
       deferred.reject("Error with http(s) request: " + err);
     } else {
-      edgechromiumdriver_version = data.trim();
+      edgechromiumdriver_version = data.replace(/[^0-9.]/g, "");
       deferred.resolve(true);
     }
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msedgedriver",
-  "version": "87.0.13",
+  "version": "87.0.14",
   "keywords": [
     "msedgedriver",
     "selenium"


### PR DESCRIPTION
The CDN URL returns an application/octet-stream content type (e.g.: ��88.0.705.81\r\n) the download of latest version fails, since it can't create a tmp folder with this name. So instead of a simple trim, we need to sanitize the returned data.